### PR TITLE
Fix bug in a link at TRANSLATIONS.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ I'm easiest to find on Twitter.
 - [Links](#links)
 
 The book 
-- Basics
+- [Basics](./1-basics)
    - [JSX](./1-basics/jsx.md)
    - [Setup](./1-basics/setup.md)
    - [First component](./1-basics/first-component.md)
@@ -37,24 +37,24 @@ The book
    - [Methods](./1-basics/methods.md)
    - [Thinking in Components](./1-basics/thinking-in-components.md)
    - [Conditional](./1-basics/conditional.md)
-- Styling
+- [Styling](./2-styling)
    - [Styled components](./2-styling/styled-components.md)
-- Images
+- [Images](./3-images)
    - [Importing images](./3-images/images.md)
-- Routing
+- [Routing](./4-routing)
    - [Routing](./4-routing/routing.md)
    - [Router and query parameters](./4-routing/params.md)
    - [Programmatic navigation](./4-routing/programmatic-navigation.md)
    - [Lazy loading](./4-routing/lazy-loading.md)
-- Advanced
+- [Advanced](./5-advanced)
    - [Context API](./5-advanced/context-api.md)
    - [Hooks](./5-advanced/hooks.md)
    - [render-props](./5-advanced/render-props.md)
-- Testing
+- [Testing](./6-testing/)
    - [Jest](./6-testing/jest.md)
    - [nock](./6-testing/nock.md)
    - [react-testing-library](./6-testing/react-testing-library.md)  
-- Redux
+- [Redux](./7-redux)
    - [Redux basics](./7-redux/redux.md)
    - [Actions](./7-redux/actions.md)
    - [Reducers](./7-redux/reducers.md)
@@ -62,9 +62,9 @@ The book
    - [Adding Redux to React](./7-redux/adding-redux-to-react.md)
    - [Sagas, side effects](./7-redux/sagas.md)
    - [Redux form](./7-redux/redux-form.md) 
-- Tools
+- [Tools](./8-tools)
    - [Storybook](./8-tools/storybook.md) 
-- Forms
+- [Forms](./9-forms)
    - [forms](./9-forms/forms.md)
    - [Forms validation](./9-forms/forms-validation.md)
    - [Formik part I](./9-forms/formik-partI.md)

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ I'm easiest to find on Twitter.
 - [Links](#links)
 
 The book 
-- [Basics](./1-basics)
+- Basics
    - [JSX](./1-basics/jsx.md)
    - [Setup](./1-basics/setup.md)
    - [First component](./1-basics/first-component.md)
@@ -37,24 +37,24 @@ The book
    - [Methods](./1-basics/methods.md)
    - [Thinking in Components](./1-basics/thinking-in-components.md)
    - [Conditional](./1-basics/conditional.md)
-- [Styling](./2-styling)
+- Styling
    - [Styled components](./2-styling/styled-components.md)
-- [Images](./3-images)
+- Images
    - [Importing images](./3-images/images.md)
-- [Routing](./4-routing)
+- Routing
    - [Routing](./4-routing/routing.md)
    - [Router and query parameters](./4-routing/params.md)
    - [Programmatic navigation](./4-routing/programmatic-navigation.md)
    - [Lazy loading](./4-routing/lazy-loading.md)
-- [Advanced](./5-advanced)
+- Advanced
    - [Context API](./5-advanced/context-api.md)
    - [Hooks](./5-advanced/hooks.md)
    - [render-props](./5-advanced/render-props.md)
-- [Testing](./6-testing/)
+- Testing
    - [Jest](./6-testing/jest.md)
    - [nock](./6-testing/nock.md)
    - [react-testing-library](./6-testing/react-testing-library.md)  
-- [Redux](./7-redux)
+- Redux
    - [Redux basics](./7-redux/redux.md)
    - [Actions](./7-redux/actions.md)
    - [Reducers](./7-redux/reducers.md)
@@ -62,9 +62,9 @@ The book
    - [Adding Redux to React](./7-redux/adding-redux-to-react.md)
    - [Sagas, side effects](./7-redux/sagas.md)
    - [Redux form](./7-redux/redux-form.md) 
-- [Tools](./8-tools)
+- Tools
    - [Storybook](./8-tools/storybook.md) 
-- [Forms](./9-forms)
+- Forms
    - [forms](./9-forms/forms.md)
    - [Forms validation](./9-forms/forms-validation.md)
    - [Formik part I](./9-forms/formik-partI.md)

--- a/TRANSLATIONS.md
+++ b/TRANSLATIONS.md
@@ -4,7 +4,7 @@ We welcome translations for the lessons in this curriculum!
 
 ## Guidelines
 
-There are [**translations**](https://github.com/softchris/react-book/tree/main/1-basics/translations) folders which contain the translated markdown files.
+There are [**translations**](https://github.com/softchris/react-book/tree/master/1-basics/translations) folders which contain the translated markdown files.
 
 Translated lessons should follow this naming convention:
 


### PR DESCRIPTION
I've changed the "translations" link at the file TRANLATIONS.md at root folder.

Before it was leading to a 404 GitHub page, now it's heading to https://github.com/softchris/react-book/tree/master/1-basics/translations.

I've just changed the word "main" to "master" in the link and now it's working.

#206 @softchris 