### PR TITLE
Removed the word 'us' written.

### DIFF
--- a/1-basics/jsx.md
+++ b/1-basics/jsx.md
@@ -117,7 +117,7 @@ You can fix this by either:
     )
     ```
 
-`React.Fragment` would be the parent element  instead of us using a `div`.
+`React.Fragment` would be the parent element instead of using a `div`.
 
 ## Summary
 


### PR DESCRIPTION
On line 120, it was written, 
`React.Fragment` would be the parent element instead of us using a `div`.
I removed 'us' from this line.